### PR TITLE
Reload current scene on player death

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -11,6 +11,7 @@ config_version=5
 [application]
 
 config/name="Project Recoil"
+run/main_scene="uid://bhxil7rr4bpxg"
 config/features=PackedStringArray("4.6", "Forward Plus")
 config/icon="res://icon.svg"
 


### PR DESCRIPTION
Create a resetLevel function in gamestate, called by the killzone that collided with the player.

Resolves #20