### PR TITLE
Level reloads when player is unable to move

### DIFF
--- a/scenes/game.tscn
+++ b/scenes/game.tscn
@@ -1544,6 +1544,7 @@ libraries/ = SubResource("AnimationLibrary_gee14")
 autoplay = &"move"
 
 [node name="Player" parent="." unique_id=1454191691 instance=ExtResource("4_lbhrr")]
+unique_name_in_owner = true
 position = Vector2(-27, -30)
 
 [node name="Camera2D" type="Camera2D" parent="." unique_id=1400858751]

--- a/src/game_state.gd
+++ b/src/game_state.gd
@@ -4,10 +4,15 @@ var player_health: int # Unused
 var current_level # Unused
 var player_score: int
 
-@onready var level_container: Node2D = $"../levelContainer"
+@onready var level_container: Node2D
+@onready var player: Player
+
 
 func _ready() -> void:
-		player_score = 0
+	player_score = 0
+
+func _process(_delta: float) -> void:
+	player_can_move()
 
 ## Reloads the active scene, used as a level reset
 func reset_level():
@@ -17,3 +22,15 @@ func reset_level():
 func increase_score(amount: int) -> void:
 	player_score += amount
 	print("Total score: " + str(player_score))
+
+## Resets level if player isn't moving and is further
+## unable to move, e.g. by being out of ammo.
+func player_can_move():
+	if player == null:
+		print("No player!")
+		return
+	if player.weapon.current_ammo == 0:
+		var time_until_reset := 1.0 # To avoid resetting at the apex of a leap
+		await get_tree().create_timer(time_until_reset).timeout
+		if player.velocity == Vector2.ZERO:
+			reset_level()

--- a/src/player.gd
+++ b/src/player.gd
@@ -10,6 +10,9 @@ class_name Player
 @onready var weapon_slot = $WeaponSlot
 @onready var weapon: Weapon = $WeaponSlot/Weapon
 
+func _ready() -> void:
+	GameState.player = self
+
 func _physics_process(delta: float) -> void:
 	if not is_on_floor():
 		velocity.y += gravity * delta


### PR DESCRIPTION
Due to ammo limit, player becomes unable to move when out of ammo. Thus, the level now resets to the beginning. Added ref to player in GameState and assigned player to ref in player's ready function.

Resolves #35