### PR TITLE
Feature/add level timer to UI

### DIFF
--- a/scenes/game.tscn
+++ b/scenes/game.tscn
@@ -36,11 +36,6 @@ follow_smoothing = 10.0
 [node name="UI" type="CanvasLayer" parent="." unique_id=838067585]
 
 [node name="HUD" parent="UI" unique_id=874038080 instance=ExtResource("4_u5sy4")]
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-grow_horizontal = 2
-grow_vertical = 2
 
 [node name="MainMenu" parent="UI" unique_id=1116656442 instance=ExtResource("8_0tnpc")]
 visible = false

--- a/scenes/hud.tscn
+++ b/scenes/hud.tscn
@@ -8,12 +8,21 @@ font_size = 24
 [sub_resource type="LabelSettings" id="LabelSettings_xlq6p"]
 font_size = 24
 
-[node name="HUD" type="Control" unique_id=874038080 node_paths=PackedStringArray("score_label", "ammo_label")]
+[sub_resource type="LabelSettings" id="LabelSettings_ahhtf"]
+font_size = 24
+
+[node name="HUD" type="Control" unique_id=874038080 node_paths=PackedStringArray("score_label", "ammo_label", "timer_label")]
+layout_direction = 2
 layout_mode = 3
-anchors_preset = 0
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 script = ExtResource("1_nt7q6")
 score_label = NodePath("AmmoCount/VSplitContainer/ScoreLabel")
 ammo_label = NodePath("AmmoCount/VSplitContainer/AmmoLabel")
+timer_label = NodePath("LevelTimer/PanelContainer/TimerLabel")
 
 [node name="AmmoCount" type="Control" parent="." unique_id=1301280991]
 layout_mode = 1
@@ -22,8 +31,6 @@ anchor_left = 1.0
 anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
-offset_right = -20.0
-offset_bottom = -10.0
 grow_horizontal = 0
 grow_vertical = 0
 size_flags_horizontal = 8
@@ -35,6 +42,8 @@ offset_left = -157.0
 offset_top = -99.0
 offset_right = -5.0
 offset_bottom = -11.0
+split_offsets = PackedInt32Array(34)
+split_offset = 34
 
 [node name="ScoreLabel" type="Label" parent="AmmoCount/VSplitContainer" unique_id=1461104721]
 layout_mode = 2
@@ -45,4 +54,30 @@ label_settings = SubResource("LabelSettings_nt7q6")
 layout_mode = 2
 text = "AMMO: XX"
 label_settings = SubResource("LabelSettings_xlq6p")
+vertical_alignment = 1
+
+[node name="LevelTimer" type="Control" parent="." unique_id=2115620499]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="PanelContainer" type="PanelContainer" parent="LevelTimer" unique_id=144559990]
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -115.0
+offset_top = 16.0
+offset_right = -20.0
+offset_bottom = 50.0
+grow_horizontal = 0
+
+[node name="TimerLabel" type="Label" parent="LevelTimer/PanelContainer" unique_id=1296950739]
+layout_mode = 2
+text = "00:00.00"
+label_settings = SubResource("LabelSettings_ahhtf")
+horizontal_alignment = 1
 vertical_alignment = 1

--- a/src/hud.gd
+++ b/src/hud.gd
@@ -1,16 +1,32 @@
 extends Control
 
-
 @export var score_label: Label
 @export var ammo_label: Label
 
-# Called when the node enters the scene tree for the first time.
+@export var timer_label: Label
+var time_elapsed: float = 0.0
+
 func _ready() -> void:
 	await GameState.game_loaded
 	_initial_update()
 	GameState.player.weapon.ammo_changed.connect(_on_ammo_changed)
 	GameState.level_score_changed.connect(_on_score_changed)
+
+# Timer using _process for millisecond precision.
+func _process(delta: float) -> void:
+	if !GameState.player.has_moved:
+		reset_time_elapsed()
+	else:
+		time_elapsed += delta
+		
+	var minutes: int = floori(time_elapsed / 60.0)
+	var seconds: int = floori(time_elapsed) % 60
+	var hundredths: int = floori(fmod(time_elapsed, 1) * 100)
 	
+	var timer_text_formatted = "%02d:%02d.%02d" % [minutes, seconds, hundredths]
+	
+	timer_label.text = timer_text_formatted
+
 func _on_ammo_changed(current, total: int):
 	update_ammo_label(current, total)
 
@@ -26,4 +42,7 @@ func update_score_label(score: int):
 
 func update_ammo_label(amount, total: int):
 	ammo_label.text = "AMMO: " + str(amount) + "/" + str(total)
+	
+func reset_time_elapsed() -> void:
+	time_elapsed = 0.0
 	

--- a/src/player.gd
+++ b/src/player.gd
@@ -14,6 +14,7 @@ class_name Player
 @onready var weapon: Weapon = $WeaponSlot/Weapon
 
 var fire_buffer_timer: float = 0.0
+var has_moved: bool = false
 
 ## Resets player fields to their defaults
 func reset_for_level(spawn_position: Vector2) -> void:
@@ -21,6 +22,7 @@ func reset_for_level(spawn_position: Vector2) -> void:
 	global_position = spawn_position
 	velocity = Vector2.ZERO
 	fire_buffer_timer = 0.0
+	has_moved = false
 
 func _physics_process(delta: float) -> void:
 	if not is_on_floor():
@@ -50,8 +52,11 @@ func try_fire_weapon() -> bool:
 	var recoil_force = weapon.shoot()
 	if recoil_force <= 0:
 		return false
-
+	
 	var look_direction = (get_global_mouse_position() - global_position).normalized()
 	velocity += -look_direction * recoil_force
 	velocity = velocity.limit_length(max_speed)
+	
+	has_moved = true
+	
 	return true


### PR DESCRIPTION
Timer counts using time between frames for greater precision than a Timer node, used to display elapsed time to the UI to the hundredth of a second.

Added has_moved boolean to player to that updated to true if the player has moved under its own power since level start/reset. Used to start the timer.

Resolves: #54